### PR TITLE
Update IntercomPatch.cs

### DIFF
--- a/IntercomDisplayInfo/IntercomDisplayInfo.cs
+++ b/IntercomDisplayInfo/IntercomDisplayInfo.cs
@@ -14,7 +14,7 @@ namespace IntercomDisplayInfo
         public override string Name => "IntercomDisplayInfo";
         public override string Description => "Turns the Intercom into a live stats HUD. Displays the round timer, team counts, and Intercom status.";
         public override string Author => "araangarciiia";
-        public override Version Version => new(1,0,0);
+        public override Version Version => new(1,0,1);
         public override Version RequiredApiVersion => new(LabApiProperties.CompiledVersion);
         
         private Harmony harmony = new("dev.araangarciiia.intercomdisplayinfo");

--- a/IntercomDisplayInfo/IntercomDisplayInfo.csproj
+++ b/IntercomDisplayInfo/IntercomDisplayInfo.csproj
@@ -23,6 +23,7 @@
         <DefineConstants>DEBUG;TRACE</DefineConstants>
         <ErrorReport>prompt</ErrorReport>
         <WarningLevel>4</WarningLevel>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/IntercomDisplayInfo/IntercomDisplayInfo.csproj
+++ b/IntercomDisplayInfo/IntercomDisplayInfo.csproj
@@ -39,7 +39,7 @@
           <HintPath>..\..\..\Documents\SCPSLDLL\14.1.3\otros\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="Assembly-CSharp">
-          <HintPath>..\..\..\Documents\SCPSLDLL\14.1.3\Assembly-CSharp.dll</HintPath>
+          <HintPath>..\..\..\Documents\SCPSLDLL\14.1.3\Assembly-CSharp-Publicized.dll</HintPath>
         </Reference>
         <Reference Include="LabApi">
           <HintPath>..\..\..\Documents\SCPSLDLL\14.1.3\LabApi.dll</HintPath>

--- a/IntercomDisplayInfo/IntercomPatch.cs
+++ b/IntercomDisplayInfo/IntercomPatch.cs
@@ -27,31 +27,19 @@ namespace IntercomDisplayInfo
             if (icomInstance == null)
                 return;
             
-            var classD = Player.List.Count(p => p.Role == RoleTypeId.ClassD);
-            var fforces = Player.List.Count(p => p.Team == Team.FoundationForces);
-            var scientist = Player.List.Count(p => p.Role == RoleTypeId.Scientist);
-            var chaos = Player.List.Count(p => p.Team == Team.ChaosInsurgency);
-            var scps = Player.List.Count(p => p.Team == Team.SCPs);
-            
-            static string GetTranslatedState(IntercomState state)
-            {
-                var translation = IntercomDisplayInfo.Instance.Translation;
-                
-                return state switch
-                {
-                    IntercomState.Ready => translation.StateReady,
-                    IntercomState.Starting => translation.StateStarting,
-                    IntercomState.InUse => translation.StateInUse,
-                    IntercomState.Cooldown => translation.StateCooldown,
-                    IntercomState.NotFound => translation.StateNotFound,
-                    _ => state.ToString()
-                };
-            }
-
+            var translation = IntercomDisplayInfo.Instance.Translation;
             var intercomState = Intercom.State;
-            string translatedState = GetTranslatedState(intercomState);
-            var remainingTime = Mathf.Round(icomInstance.RemainingTime);
-            string intercomRemainingTime = remainingTime > 1 ? remainingTime.ToString() : "";
+            string translatedState = intercomState switch
+            {
+                IntercomState.Ready => translation.StateReady,
+                IntercomState.Starting => translation.StateStarting,
+                IntercomState.InUse => translation.StateInUse,
+                IntercomState.Cooldown => translation.StateCooldown,
+                IntercomState.NotFound => translation.StateNotFound,
+                _ => intercomState.ToString()
+            };
+            
+            var remainingTime = Mathf.CeilToInt(icomInstance.RemainingTime).ToString();
             string roundTime = $"{Round.Duration.TotalSeconds / 60:00}:{Round.Duration.TotalSeconds % 60:00}";
             
             StringBuilder stringBuilder = new StringBuilder();
@@ -61,28 +49,29 @@ namespace IntercomDisplayInfo
 
             stringBuilder.AppendLine($"<color=white>{IntercomDisplayInfo.Instance.Translation.Information}</color>");
             
+            
+            var teamCounts = Player.ReadyList.GroupBy(p => p.Team).ToDictionary(g => g.Key, g => (byte)g.Count());
+            
             if (IntercomDisplayInfo.Instance.Config.ClassD)
-                stringBuilder.AppendLine($"<color=#f7a71b>{IntercomDisplayInfo.Instance.Translation.ClassDText} - {classD}</color>");
+                stringBuilder.AppendLine($"<color=#f7a71b>{IntercomDisplayInfo.Instance.Translation.ClassDText} - {teamCounts.GetValueOrDefault(Team.ClassD)}</color>");
             
             if (IntercomDisplayInfo.Instance.Config.FForces)
-                stringBuilder.AppendLine($"<color=#3550db>{IntercomDisplayInfo.Instance.Translation.FoundationForces} - {fforces}</color>");
+                stringBuilder.AppendLine($"<color=#3550db>{IntercomDisplayInfo.Instance.Translation.FoundationForces} - {teamCounts.GetValueOrDefault(Team.FoundationForces)}</color>");
             
             if (IntercomDisplayInfo.Instance.Config.Scientist)
-                stringBuilder.AppendLine($"<color=#d4eb7a>{IntercomDisplayInfo.Instance.Translation.Scientists} - {scientist}</color>");
+                stringBuilder.AppendLine($"<color=#d4eb7a>{IntercomDisplayInfo.Instance.Translation.Scientists} - {teamCounts.GetValueOrDefault(Team.Scientists)}</color>");
             
             if (IntercomDisplayInfo.Instance.Config.Chaos)
-                stringBuilder.AppendLine($"<color=#227a0f>{IntercomDisplayInfo.Instance.Translation.ChaosInsurgency} - {chaos}</color>");
+                stringBuilder.AppendLine($"<color=#227a0f>{IntercomDisplayInfo.Instance.Translation.ChaosInsurgency} - {teamCounts.GetValueOrDefault(Team.ChaosInsurgency)}</color>");
             
             if (IntercomDisplayInfo.Instance.Config.Scps)
-                stringBuilder.AppendLine($"<color=#c21010>{IntercomDisplayInfo.Instance.Translation.SCPs} - {scps}</color>");
+                stringBuilder.AppendLine($"<color=#c21010>{IntercomDisplayInfo.Instance.Translation.SCPs} - {teamCounts.GetValueOrDefault(Team.SCPs)}</color>");
 
             stringBuilder.AppendLine("<color=white>-------------------------------------</color>");
             
             stringBuilder.AppendLine($"{IntercomDisplayInfo.Instance.Translation.State} - {translatedState}");
-            if (Intercom.State == IntercomState.InUse || Intercom.State == IntercomState.Cooldown)
-            {
-                stringBuilder.AppendLine($"{IntercomDisplayInfo.Instance.Translation.Timer} {intercomRemainingTime}");
-            }
+            if (intercomState is IntercomState.InUse or IntercomState.Cooldown)
+                stringBuilder.AppendLine($"{IntercomDisplayInfo.Instance.Translation.Timer} {remainingTime}");
             
             
             singletonInstance.Network_overrideText = stringBuilder.ToString();

--- a/IntercomDisplayInfo/IntercomPatch.cs
+++ b/IntercomDisplayInfo/IntercomPatch.cs
@@ -12,21 +12,11 @@ namespace IntercomDisplayInfo
     [HarmonyPatch(typeof(Intercom), nameof(Intercom.Update))]
     public class IntercomPatch
     {
-        private static readonly FieldInfo SingletonField = AccessTools.Field(typeof(IntercomDisplay), "_singleton");
-        private static readonly FieldInfo IcomField = AccessTools.Field(typeof(IntercomDisplay), "_icom");
-        
+
         [HarmonyPrefix]
         public static void OnUpdate()
         {
-            var singletonInstance = (IntercomDisplay)SingletonField.GetValue(null);
-            
-            if (singletonInstance == null)
-                return;
-            
-            var icomInstance = (Intercom)IcomField.GetValue(singletonInstance);
-            if (icomInstance == null)
-                return;
-            
+
             var translation = IntercomDisplayInfo.Instance.Translation;
             var intercomState = Intercom.State;
             string translatedState = intercomState switch
@@ -38,35 +28,50 @@ namespace IntercomDisplayInfo
                 IntercomState.NotFound => translation.StateNotFound,
                 _ => intercomState.ToString()
             };
-            
-            var remainingTime = Mathf.CeilToInt(icomInstance.RemainingTime).ToString();
+
+            var remainingTime = Mathf.CeilToInt(Intercom._singleton.RemainingTime).ToString();
             string roundTime = $"{Round.Duration.TotalSeconds / 60:00}:{Round.Duration.TotalSeconds % 60:00}";
-            
+
             StringBuilder stringBuilder = new StringBuilder();
-            
+
             if (IntercomDisplayInfo.Instance.Config.RoundTimer)
                 stringBuilder.AppendLine($"{IntercomDisplayInfo.Instance.Translation.RoundTimer} - {roundTime}");
 
             stringBuilder.AppendLine($"<color=white>{IntercomDisplayInfo.Instance.Translation.Information}</color>");
-            
-            
+
+
             var teamCounts = Player.ReadyList.GroupBy(p => p.Team).ToDictionary(g => g.Key, g => (byte)g.Count());
-            
+
             if (IntercomDisplayInfo.Instance.Config.ClassD)
-                stringBuilder.AppendLine($"<color=#f7a71b>{IntercomDisplayInfo.Instance.Translation.ClassDText} - {teamCounts.GetValueOrDefault(Team.ClassD)}</color>");
-            
+            {
+                teamCounts.TryGetValue(Team.ClassD, out byte classDCount);
+                stringBuilder.AppendLine(
+                    $"<color=#f7a71b>{IntercomDisplayInfo.Instance.Translation.ClassDText} - {classDCount}</color>");
+            }
+
             if (IntercomDisplayInfo.Instance.Config.FForces)
-                stringBuilder.AppendLine($"<color=#3550db>{IntercomDisplayInfo.Instance.Translation.FoundationForces} - {teamCounts.GetValueOrDefault(Team.FoundationForces)}</color>");
+            {
+                teamCounts.TryGetValue(Team.ClassD, out byte fforcesCount);
+                stringBuilder.AppendLine($"<color=#3550db>{IntercomDisplayInfo.Instance.Translation.FoundationForces} - {fforcesCount}</color>");
+            }
             
             if (IntercomDisplayInfo.Instance.Config.Scientist)
-                stringBuilder.AppendLine($"<color=#d4eb7a>{IntercomDisplayInfo.Instance.Translation.Scientists} - {teamCounts.GetValueOrDefault(Team.Scientists)}</color>");
+            {
+                teamCounts.TryGetValue(Team.Scientists, out byte scientistCount);
+                stringBuilder.AppendLine($"<color=#d4eb7a>{IntercomDisplayInfo.Instance.Translation.Scientists} - {scientistCount}</color>");
+            }
             
             if (IntercomDisplayInfo.Instance.Config.Chaos)
-                stringBuilder.AppendLine($"<color=#227a0f>{IntercomDisplayInfo.Instance.Translation.ChaosInsurgency} - {teamCounts.GetValueOrDefault(Team.ChaosInsurgency)}</color>");
+            {
+                teamCounts.TryGetValue(Team.ChaosInsurgency, out byte chaosCount);
+                stringBuilder.AppendLine($"<color=#227a0f>{IntercomDisplayInfo.Instance.Translation.ChaosInsurgency} - {chaosCount}</color>");
+            }
             
             if (IntercomDisplayInfo.Instance.Config.Scps)
-                stringBuilder.AppendLine($"<color=#c21010>{IntercomDisplayInfo.Instance.Translation.SCPs} - {teamCounts.GetValueOrDefault(Team.SCPs)}</color>");
-
+            {
+                teamCounts.TryGetValue(Team.SCPs, out byte scpCount);
+                stringBuilder.AppendLine($"<color=#c21010>{IntercomDisplayInfo.Instance.Translation.SCPs} - {scpCount}</color>");
+            }
             stringBuilder.AppendLine("<color=white>-------------------------------------</color>");
             
             stringBuilder.AppendLine($"{IntercomDisplayInfo.Instance.Translation.State} - {translatedState}");
@@ -74,7 +79,7 @@ namespace IntercomDisplayInfo
                 stringBuilder.AppendLine($"{IntercomDisplayInfo.Instance.Translation.Timer} {remainingTime}");
             
             
-            singletonInstance.Network_overrideText = stringBuilder.ToString();
+            IntercomDisplay._singleton.Network_overrideText = stringBuilder.ToString();
             stringBuilder.Clear();
         }
     }


### PR DESCRIPTION
Optimized the way team player counts were retrieved and used
Made it so remaining time just uses Mathf.CeilToInt(floatTime).ToString(); instead of whatever else was happening
Removed the unnecessary static method for getting translated state